### PR TITLE
Ensure docs get deployed on release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,13 @@ on:
           - preminor
           - premajor
           - prerelease
+      package:
+        description: |
+          Package to publish
+        required: true
+        type: choice
+        options:
+          - "@geneontology/web-components"
 
 jobs:
   publish:
@@ -22,6 +29,9 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      previous_version: ${{ steps.increment_version.outputs.previous_version }}
+      new_version: ${{ steps.increment_version.outputs.new_version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,9 +44,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
         # This git user config is recommended by the actions/checkout documentation
         # https://github.com/actions/checkout/tree/v4.2.2?tab=readme-ov-file#push-a-commit-using-the-built-in-token
       - name: Configure git user
@@ -44,28 +51,53 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Increment version
+      - name: Increment version for ${{ inputs.package }}
+        id: increment_version
         run: |
-          npm version --preid=beta --workspaces --include-workspace-root --no-git-tag-version $RELEASE_TYPE
-          echo "NEW_VERSION=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+          echo 'previous_version='$(npm pkg get version --workspaces | jq -r '."${{ inputs.package }}"') >> $GITHUB_OUTPUT
+          npm version --preid=beta --no-git-tag-version --workspace ${{ inputs.package }} ${{ inputs.release-type }}
+          echo 'new_version='$(npm pkg get version --workspaces | jq -r '."${{ inputs.package }}"') >> $GITHUB_OUTPUT
 
       - name: Commit version change
         run: |
-          git commit -a -m "${{ env.NEW_VERSION }}"
+          git commit -a -m "${{ steps.increment_version.outputs.new_version }}"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: npm run build
+
       - name: Publish to NPM
-        run: npm publish --provenance --access public --workspace packages/web-components
+        run: npm publish --provenance --access public --workspace ${{ inputs.package }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build
+
+  deploy_docs:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+
+  create_release:
+    runs-on: ubuntu-latest
+    needs: publish
+    if: ${{ !startsWith(inputs.release-type, 'pre') }}
+    steps:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ env.NEW_VERSION }}
+          tag_name: v${{ needs.publish.outputs.new_version }}
           generate_release_notes: true
-          prerelease: ${{ startsWith(github.event.inputs.release-type, 'pre') }}
+          prerelease: ${{ startsWith(inputs.release-type, 'pre') }}
+

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -102,4 +102,3 @@ jobs:
           tag_name: v${{ needs.publish.outputs.new_version }}
           generate_release_notes: true
           prerelease: ${{ startsWith(inputs.release-type, 'pre') }}
-

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish
     if: ${{ !startsWith(inputs.release-type, 'pre') }}
+    permissions:
+      contents: write
     steps:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -9,83 +9,13 @@ For the latest stable version of the GO web components, please visit:
 
 ---
 
-[![Built With Stencil](https://img.shields.io/badge/-Built%20With%20Stencil-16161d.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI%2BCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI%2BCgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU%2BCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik00MjQuNywzNzMuOWMwLDM3LjYtNTUuMSw2OC42LTkyLjcsNjguNkgxODAuNGMtMzcuOSwwLTkyLjctMzAuNy05Mi43LTY4LjZ2LTMuNmgzMzYuOVYzNzMuOXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTQyNC43LDI5Mi4xSDE4MC40Yy0zNy42LDAtOTIuNy0zMS05Mi43LTY4LjZ2LTMuNkgzMzJjMzcuNiwwLDkyLjcsMzEsOTIuNyw2OC42VjI5Mi4xeiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNDI0LjcsMTQxLjdIODcuN3YtMy42YzAtMzcuNiw1NC44LTY4LjYsOTIuNy02OC42SDMzMmMzNy45LDAsOTIuNywzMC43LDkyLjcsNjguNlYxNDEuN3oiLz4KPC9zdmc%2BCg%3D%3D&colorA=16161d&style=flat-square)](https://stenciljs.com)
-
 # GO Web Components
 
-This repository contains a collection of web components produced by the Gene Ontology Consortium focusing on the display of GO Annotation data and GO-CAM models.
+Easily integrate GO data into your website with GO Web Components: a collection of reusable web components produced by the [Gene Ontology Consortium](https://geneontology.org) focusing on the display of GO Annotation data and GO-CAM models.
 
-## Installation
+## Getting Started
 
-These web components are framework-agnostic and designed to be integrated into any web application. The two main ways to install the components are via NPM or by using files served from a CDN.
-
-### NPM
-
-To install the components via NPM, run the following command:
-
-```bash
-npm install @geneontology/web-components
-```
-
-Once the package is installed, there are two ways to include the components in your application. The first method is to use the top-level lazy loader. Add this code near the beginning of your application code:
-
-```javascript
-import "@geneontology/web-components";
-```
-
-This will allow you to use all custom elements provided by this package. The necessary code for each component is fetched on demand when it is first used.
-
-The second method is to import the individual component or components directly. For example, to use only `go-annotation-ribbon` component:
-
-```javascript
-import "@geneontology/web-components/go-annotation-ribbon";
-```
-
-In this case, no dynamic code fetching happens at runtime. This can lead to a more performant final application, but it requires you manage the imports for each component you use.
-
-### CDN
-
-If your application does not use a build system or package manager, you can include the components directly from a CDN. Add the following script tag to your HTML file:
-
-```html
-<script
-  type="module"
-  src="https://unpkg.com/@geneontology/web-components"
-></script>
-```
-
-## Usage
-
-### `go-annotation-ribbon`
-
-The `go-annotation-ribbon` component displays a ribbon of GO terms associated with one or more gene products.
-
-#### Example
-
-```html
-<go-annotation-ribbon subjects="RGD:620474,RGD:3889"></go-annotation-ribbon>
-```
-
-#### Documentation
-
-https://github.com/geneontology/web-components/blob/main/src/components/go-ribbon/readme.md
-
-### `go-gocam-viewer`
-
-The `go-gocam-viewer` component displays a GO-CAM model as a network diagram along with a list of processes and activities in the model.
-
-#### Example
-
-```html
-<go-gocam-viewer
-  gocam-id="635b1e3e00001811"
-  show-legend="true"
-></go-gocam-viewer>
-```
-
-#### Documentation
-
-https://github.com/geneontology/web-components/blob/main/src/components/go-gocam-pathway/readme.md
+Get started by checking out the [full documentation](https://geneontology.github.io/web-components/).
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "go-web-components",
-  "version": "0.1.3",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "go-web-components",
-      "version": "0.1.3",
+      "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -24968,7 +24968,7 @@
     },
     "website": {
       "name": "web-components-docs",
-      "version": "0.1.3",
+      "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-web-components",
-  "version": "0.1.3",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -1,0 +1,71 @@
+# @geneontology/web-components
+
+Easily integrate GO data into your website with GO Web Components: a collection of reusable web components produced by the [Gene Ontology Consortium](https://geneontology.org) focusing on the display of GO Annotation data and GO-CAM models.
+
+## Documentation
+
+For full documentation see https://geneontology.github.io/web-components/.
+
+## Installation
+
+These web components are framework-agnostic and designed to be integrated into any web application. The two main ways to install the components are via NPM or by using files served from a CDN.
+
+### NPM
+
+To install the components via NPM, run the following command:
+
+```bash
+npm install @geneontology/web-components
+```
+
+Once the package is installed, there are two ways to include the components in your application. The first method is to use the top-level lazy loader. Add this code near the beginning of your application code:
+
+```javascript
+import "@geneontology/web-components";
+```
+
+This will allow you to use all custom elements provided by this package. The necessary code for each component is fetched on demand when it is first used.
+
+The second method is to import the individual component or components directly. For example, to use only `go-annotation-ribbon` component:
+
+```javascript
+import "@geneontology/web-components/go-annotation-ribbon";
+```
+
+In this case, no dynamic code fetching happens at runtime. This can lead to a more performant final application, but it requires you manage the imports for each component you use.
+
+### CDN
+
+If your application does not use a build system or package manager, you can include the components directly from a CDN. Add the following script tag to your HTML file:
+
+```html
+<script
+  type="module"
+  src="https://unpkg.com/@geneontology/web-components"
+></script>
+```
+
+## Usage
+
+### `go-annotation-ribbon`
+
+The `go-annotation-ribbon` component displays a ribbon of GO terms associated with one or more gene products.
+
+#### Example
+
+```html
+<go-annotation-ribbon subjects="RGD:620474,RGD:3889"></go-annotation-ribbon>
+```
+
+### `go-gocam-viewer`
+
+The `go-gocam-viewer` component displays a GO-CAM model as a network diagram along with a list of processes and activities in the model.
+
+#### Example
+
+```html
+<go-gocam-viewer
+  gocam-id="635b1e3e00001811"
+  show-legend="true"
+></go-gocam-viewer>
+```

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -15,8 +15,7 @@
   "bugs": {
     "url": "https://github.com/geneontology/web-components/issues"
   },
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
+  "main": "dist/web-components/web-components.esm.js",
   "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
@@ -24,8 +23,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/web-components/web-components.esm.js",
-      "require": "./dist/web-components/web-components.js"
+      "import": "./dist/web-components/web-components.esm.js"
     },
     "./*": {
       "types": "./dist/components/*.d.ts",
@@ -33,8 +31,7 @@
     },
     "./loader": {
       "types": "./loader/index.d.ts",
-      "import": "./loader/index.js",
-      "require": "./loader/index.cjs"
+      "import": "./loader/index.js"
     }
   },
   "files": [

--- a/website/README.md
+++ b/website/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ### Installation
 
 ```
-$ yarn
+$ npm install
 ```
 
 ### Local Development
 
 ```
-$ yarn start
+$ npm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,23 +19,7 @@ This command starts a local development server and opens up a browser window. Mo
 ### Build
 
 ```
-$ yarn build
+$ npm build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,7 +1,8 @@
 import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
-import { version } from "./package.json";
+
+import { version as webComponentsVersion } from "../packages/web-components/package.json";
 
 const config: Config = {
   title: "GO Web Components",
@@ -69,7 +70,7 @@ const config: Config = {
         {
           type: "html",
           position: "right",
-          value: `Version: ${version}`,
+          value: `Version: ${webComponentsVersion}`,
         },
         {
           href: "https://github.com/geneontology/web-components",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-components-docs",
-  "version": "0.1.3",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-components-docs",
-      "version": "0.1.3",
+      "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components-docs",
-  "version": "0.1.3",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
These changes:

* Keep the `version` numbers in private workspaces (root, website) at `0.0.0`
* When the publish workflow runs, only increments a single workspace's version number (selectable as a workflow input, although there is only one option -- `@geneontology/web-components` -- for now)
* Ensure that docs get published at the end of doing the NPM publish
* Rearrange README content so that something useful shows up on the NPM page