### PR TITLE
Use shadow DOM for EntityAutocomplete

### DIFF
--- a/packages/web-components/src/components/entity-autocomplete/entity-autocomplete.css
+++ b/packages/web-components/src/components/entity-autocomplete/entity-autocomplete.css
@@ -11,7 +11,6 @@
   font-family: var(--font-family);
 }
 
-
 * {
   box-sizing: border-box;
 }

--- a/packages/web-components/src/components/entity-autocomplete/entity-autocomplete.css
+++ b/packages/web-components/src/components/entity-autocomplete/entity-autocomplete.css
@@ -1,22 +1,21 @@
 /* Based on https://www.w3schools.com/howto/howto_js_autocomplete.asp */
 
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css");
-
-:root {
+:host {
   --font-family: Lato, sans-serif;
   --font-size: 12px;
   --autocomplete-width: 310px;
   --autocomplete-item-font-size: 10px;
   --autocomplete-item-height: 300px;
+
+  font-size: var(--font-size);
+  font-family: var(--font-family);
 }
+
 
 * {
   box-sizing: border-box;
 }
-body {
-  font-size: var(--font-size);
-  font-family: var(--font-family);
-}
+
 .autocomplete {
   /*the container must be positioned relative:*/
   position: relative;
@@ -100,23 +99,18 @@ a {
   text-decoration: none;
 }
 
-.autocomplete i {
+.autocomplete .icon {
   position: absolute;
 }
 
-.icon {
-  padding: 10px;
-  min-width: 40px;
-}
-
 .icon-left {
-  padding: 10px;
-  left: 0px;
+  top: 10px;
+  left: 10px;
 }
 
 .icon-right {
-  padding: 10px;
-  right: 0px;
+  top: 10px;
+  right: 10px;
   cursor: pointer;
 }
 

--- a/packages/web-components/src/components/entity-autocomplete/entity-autocomplete.tsx
+++ b/packages/web-components/src/components/entity-autocomplete/entity-autocomplete.tsx
@@ -11,7 +11,7 @@ import * as dbxrefs from "@geneontology/dbxrefs";
 @Component({
   tag: "go-entity-autocomplete",
   styleUrl: "entity-autocomplete.css",
-  shadow: false,
+  shadow: true,
 })
 export class EntityAutocomplete {
   searchBox: HTMLInputElement;
@@ -123,7 +123,7 @@ export class EntityAutocomplete {
       ""
     ) : (
       <div class="autocomplete">
-        <i class="fas fa-search icon-left"></i>
+        <span class="icon icon-left">{this.renderSearchIcon()}</span>
         <input
           type="text"
           class="input-field"
@@ -132,14 +132,15 @@ export class EntityAutocomplete {
           ref={(el) => (this.searchBox = el as HTMLInputElement)}
           onInput={(evt) => this.newSearch(evt)}
         ></input>
-        <i
-          class="far fa-times-circle icon-right"
+        <span
+          class="icon icon-right"
           onClick={() => {
             this.docs = undefined;
             this.value = "";
           }}
-        ></i>
-
+        >
+          {this.renderClearIcon()}
+        </span>
         {!this.docs ? (
           ""
         ) : (
@@ -193,6 +194,35 @@ export class EntityAutocomplete {
           }
         </span>
       </div>
+    );
+  }
+
+  renderSearchIcon() {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        fill="currentColor"
+        viewBox="0 0 16 16"
+      >
+        <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0" />
+      </svg>
+    );
+  }
+
+  renderClearIcon() {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        fill="currentColor"
+        viewBox="0 0 16 16"
+      >
+        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16" />
+        <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708" />
+      </svg>
     );
   }
 }


### PR DESCRIPTION
These changes update the `EntityAutocomplete` component to use the shadow DOM. This required the disuse of Font Awesome icons. Instead we're inlining SVG from [Bootstrap Icons](https://icons.getbootstrap.com/). There is a separate task to consider whether this or something else is a good long-term solution (https://github.com/geneontology/wc-gocam-viz/issues/62). I didn't do a full-scale cleanup of the component since it is just an internal one; this is just the bare minimum to be functional and use the shadow DOM.