### PR TITLE
Add internal component for displaying version number

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -5,9 +5,9 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { ColorByOption, IRibbonCellEvent, IRibbonGroup, IRibbonGroupEvent, IRibbonModel, IRibbonSubject, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
+import { ColorByOption, IRibbonCellEvent, IRibbonGroup, IRibbonGroupEvent, IRibbonModel, IRibbonSubject, Placement, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
 import { Cam } from "./globals/@noctua.form";
-export { ColorByOption, IRibbonCellEvent, IRibbonGroup, IRibbonGroupEvent, IRibbonModel, IRibbonSubject, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
+export { ColorByOption, IRibbonCellEvent, IRibbonGroup, IRibbonGroupEvent, IRibbonModel, IRibbonSubject, Placement, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
 export { Cam } from "./globals/@noctua.form";
 export namespace Components {
     /**
@@ -459,6 +459,15 @@ export namespace Components {
         "parentCy": any;
     }
     /**
+     * A popover component that displays information about the web components library.
+     */
+    interface GoInfoPopover {
+        /**
+          * @default "bottom-start"
+         */
+        "placement": Placement;
+    }
+    /**
      * The Spinner component displays a loading spinner with an optional message.
      */
     interface GoSpinner {
@@ -654,6 +663,15 @@ declare global {
         new (): HTMLGoGocamViewerSidebarElement;
     };
     /**
+     * A popover component that displays information about the web components library.
+     */
+    interface HTMLGoInfoPopoverElement extends Components.GoInfoPopover, HTMLStencilElement {
+    }
+    var HTMLGoInfoPopoverElement: {
+        prototype: HTMLGoInfoPopoverElement;
+        new (): HTMLGoInfoPopoverElement;
+    };
+    /**
      * The Spinner component displays a loading spinner with an optional message.
      */
     interface HTMLGoSpinnerElement extends Components.GoSpinner, HTMLStencilElement {
@@ -672,6 +690,7 @@ declare global {
         "go-gocam-viewer": HTMLGoGocamViewerElement;
         "go-gocam-viewer-legend": HTMLGoGocamViewerLegendElement;
         "go-gocam-viewer-sidebar": HTMLGoGocamViewerSidebarElement;
+        "go-info-popover": HTMLGoInfoPopoverElement;
         "go-spinner": HTMLGoSpinnerElement;
     }
 }
@@ -1136,6 +1155,15 @@ declare namespace LocalJSX {
         "parentCy"?: any;
     }
     /**
+     * A popover component that displays information about the web components library.
+     */
+    interface GoInfoPopover {
+        /**
+          * @default "bottom-start"
+         */
+        "placement"?: Placement;
+    }
+    /**
      * The Spinner component displays a loading spinner with an optional message.
      */
     interface GoSpinner {
@@ -1151,6 +1179,7 @@ declare namespace LocalJSX {
         "go-gocam-viewer": GoGocamViewer;
         "go-gocam-viewer-legend": GoGocamViewerLegend;
         "go-gocam-viewer-sidebar": GoGocamViewerSidebar;
+        "go-info-popover": GoInfoPopover;
         "go-spinner": GoSpinner;
     }
 }
@@ -1217,6 +1246,10 @@ declare module "@stencil/core" {
              * The GO-CAM Viewer Sidebar
              */
             "go-gocam-viewer-sidebar": LocalJSX.GoGocamViewerSidebar & JSXBase.HTMLAttributes<HTMLGoGocamViewerSidebarElement>;
+            /**
+             * A popover component that displays information about the web components library.
+             */
+            "go-info-popover": LocalJSX.GoInfoPopover & JSXBase.HTMLAttributes<HTMLGoInfoPopoverElement>;
             /**
              * The Spinner component displays a loading spinner with an optional message.
              */

--- a/packages/web-components/src/components/annotation-ribbon-strips/annotation-ribbon-strips.scss
+++ b/packages/web-components/src/components/annotation-ribbon-strips/annotation-ribbon-strips.scss
@@ -74,6 +74,12 @@
   --loading-spinner-size: 2em;
 
   display: block;
+  overflow-x: auto;
+}
+
+.container {
+  width: fit-content;
+  position: relative;
 }
 
 .ribbon {
@@ -157,6 +163,12 @@ go-annotation-ribbon-cell {
 
 go-spinner {
   --size: var(--loading-spinner-size);
+}
+
+go-info-popover {
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .clickable {

--- a/packages/web-components/src/components/annotation-ribbon-strips/annotation-ribbon-strips.tsx
+++ b/packages/web-components/src/components/annotation-ribbon-strips/annotation-ribbon-strips.tsx
@@ -428,10 +428,13 @@ export class AnnotationRibbonStrips {
     // Data is present, show the ribbon
     return (
       <Host>
-        <table class="ribbon">
-          {this.renderCategories()}
-          {this.renderSubjects()}
-        </table>
+        <div class="container">
+          <table class="ribbon">
+            {this.renderCategories()}
+            {this.renderSubjects()}
+          </table>
+          <go-info-popover placement="bottom-end"></go-info-popover>
+        </div>
       </Host>
     );
   }

--- a/packages/web-components/src/components/gocam-viewer/gocam-viewer.scss
+++ b/packages/web-components/src/components/gocam-viewer/gocam-viewer.scss
@@ -169,6 +169,8 @@
 
 .gocam-panel-header-buttons {
   white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 
 button {
@@ -220,4 +222,8 @@ go-gocam-viewer-legend {
 
 go-gocam-viewer-sidebar {
   --height: var(--graph-height);
+}
+
+go-info-popover {
+  padding: 0 0.6em;
 }

--- a/packages/web-components/src/components/gocam-viewer/gocam-viewer.tsx
+++ b/packages/web-components/src/components/gocam-viewer/gocam-viewer.tsx
@@ -776,6 +776,7 @@ export class GocamViewer {
                     : "Expand Protein Complexes"}
                 </button>
                 <button onClick={() => this.resetView()}>Reset View</button>
+                <go-info-popover placement="bottom-end"></go-info-popover>
               </div>
             </div>
             <div class="panel-body">

--- a/packages/web-components/src/components/info-popover/index.html
+++ b/packages/web-components/src/components/info-popover/index.html
@@ -26,14 +26,24 @@
       <option>left-start</option>
       <option>left-end</option>
     </select>
-    <div style="display: flex; justify-content: center; align-items: center; width: 100%; height: 400px;">
+    <div
+      style="
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 400px;
+      "
+    >
       <go-info-popover placement="top"></go-info-popover>
     </div>
     <script>
       const popover = document.querySelector("go-info-popover");
-      document.getElementById("placement").addEventListener("change", function (e) {
-        popover.placement = e.target.value;
-      });
+      document
+        .getElementById("placement")
+        .addEventListener("change", function (e) {
+          popover.placement = e.target.value;
+        });
     </script>
   </body>
 </html>

--- a/packages/web-components/src/components/info-popover/index.html
+++ b/packages/web-components/src/components/info-popover/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Info Popover</title>
+
+    <script type="module" src="/build/web-components.esm.js"></script>
+    <script nomodule src="/build/web-components.js"></script>
+  </head>
+  <body>
+    <select id="placement">
+      <option selected>top</option>
+      <option>top-start</option>
+      <option>top-end</option>
+      <option>right</option>
+      <option>right-start</option>
+      <option>right-end</option>
+      <option>bottom</option>
+      <option>bottom-start</option>
+      <option>bottom-end</option>
+      <option>left</option>
+      <option>left-start</option>
+      <option>left-end</option>
+    </select>
+    <div style="display: flex; justify-content: center; align-items: center; width: 100%; height: 400px;">
+      <go-info-popover placement="top"></go-info-popover>
+    </div>
+    <script>
+      const popover = document.querySelector("go-info-popover");
+      document.getElementById("placement").addEventListener("change", function (e) {
+        popover.placement = e.target.value;
+      });
+    </script>
+  </body>
+</html>

--- a/packages/web-components/src/components/info-popover/info-popover.scss
+++ b/packages/web-components/src/components/info-popover/info-popover.scss
@@ -1,0 +1,101 @@
+$offset: -4px;
+
+:host {
+  display: inline-block;
+}
+
+.container {
+  position: relative;
+  font-family: sans-serif;
+  font-size: 0.9em;
+  font-weight: normal;
+  display: inline-block;
+}
+
+.trigger {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1em;
+  height: 1em;
+  color: rgba(128, 128, 128, 0.5);
+  border: 2px solid currentColor;
+  border-radius: 9999px;
+  cursor: pointer;
+}
+
+.popover {
+  position: absolute;
+  z-index: 1000;
+  background-color: white;
+  color: black;
+  border: 1px solid #ccc;
+  box-shadow: rgba(0, 0, 0, 0.1) 0 2px 4px;
+  padding: 0.5em;
+  line-height: 1.5;
+
+  &.top {
+    top: $offset;
+    left: 50%;
+    transform: translateX(-50%) translateY(-100%);
+  }
+  &.top-start {
+    top: $offset;
+    left: 0;
+    transform: translateY(-100%);
+  }
+  &.top-end {
+    top: $offset;
+    right: 0;
+    transform: translateY(-100%);
+  }
+  &.right {
+    top: 50%;
+    right: $offset;
+    transform: translateY(-50%) translateX(100%);
+  }
+  &.right-start {
+    top: 0;
+    right: $offset;
+    transform: translateX(100%);
+  }
+  &.right-end {
+    bottom: 0;
+    right: $offset;
+    transform: translateX(100%);
+  }
+  &.bottom {
+    bottom: $offset;
+    left: 50%;
+    transform: translateX(-50%) translateY(100%);
+  }
+  &.bottom-start {
+    bottom: $offset;
+    left: 0;
+    transform: translateY(100%);
+  }
+  &.bottom-end {
+    bottom: $offset;
+    right: 0;
+    transform: translateY(100%);
+  }
+  &.left {
+    top: 50%;
+    left: $offset;
+    transform: translateY(-50%) translateX(-100%);
+  }
+  &.left-start {
+    top: 0;
+    left: $offset;
+    transform: translateX(-100%);
+  }
+  &.left-end {
+    bottom: 0;
+    left: $offset;
+    transform: translateX(-100%);
+  }
+}
+
+.no-wrap {
+  white-space: nowrap;
+}

--- a/packages/web-components/src/components/info-popover/info-popover.scss
+++ b/packages/web-components/src/components/info-popover/info-popover.scss
@@ -14,14 +14,19 @@ $offset: -4px;
 
 .trigger {
   display: flex;
+  box-sizing: border-box;
+  padding: 0;
   justify-content: center;
   align-items: center;
-  width: 1em;
-  height: 1em;
+  width: 18px;
+  height: 18px;
+  background: none;
   color: rgba(128, 128, 128, 0.5);
   border: 2px solid currentColor;
   border-radius: 9999px;
   cursor: pointer;
+  font-size: 13px;
+  font-weight: bold;
 }
 
 .popover {

--- a/packages/web-components/src/components/info-popover/info-popover.tsx
+++ b/packages/web-components/src/components/info-popover/info-popover.tsx
@@ -18,20 +18,29 @@ export class InfoPopover {
 
   @Prop() placement: Placement = "bottom-start";
 
-  private handleTriggerClick(event: MouseEvent) {
-    console.log("click", this.isOpen);
+  private handleTriggerClick = (event: MouseEvent) => {
     event.preventDefault();
     this.isOpen = !this.isOpen;
-  }
+  };
 
   render() {
     return (
       <div class="container">
-        <div class="trigger" onClick={(e) => this.handleTriggerClick(e)}>
+        <buttton
+          class="trigger"
+          id="popover-trigger"
+          onClick={this.handleTriggerClick}
+          aria-label="Information about component library"
+        >
           ?
-        </div>
+        </buttton>
         {this.isOpen && (
-          <div class={`popover ${this.placement}`}>
+          <div
+            class={`popover ${this.placement}`}
+            role="tooltip"
+            aria-describedby="popover-trigger"
+            aria-hidden={!this.isOpen ? "true" : "false"}
+          >
             <a
               href="https://geneontology.github.io/web-components/"
               target="_blank"

--- a/packages/web-components/src/components/info-popover/info-popover.tsx
+++ b/packages/web-components/src/components/info-popover/info-popover.tsx
@@ -1,0 +1,50 @@
+import { Component, h, Prop, State } from "@stencil/core";
+import { Placement } from "../../globals/models";
+
+import { version } from "../../../package.json";
+
+/**
+ * A popover component that displays information about the web components library.
+ *
+ * @internal
+ */
+@Component({
+  tag: "go-info-popover",
+  styleUrl: "info-popover.scss",
+  shadow: true,
+})
+export class InfoPopover {
+  @State() isOpen: boolean = false;
+
+  @Prop() placement: Placement = "bottom-start";
+
+  private handleTriggerClick(event: MouseEvent) {
+    console.log("click", this.isOpen);
+    event.preventDefault();
+    this.isOpen = !this.isOpen;
+  }
+
+  render() {
+    return (
+      <div class="container">
+        <div class="trigger" onClick={(e) => this.handleTriggerClick(e)}>
+          ?
+        </div>
+        {this.isOpen && (
+          <div class={`popover ${this.placement}`}>
+            <a
+              href="https://geneontology.github.io/web-components/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="no-wrap"
+            >
+              @geneontology/web-components
+            </a>
+            <br />
+            Version: {version}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/packages/web-components/src/components/info-popover/info-popover.tsx
+++ b/packages/web-components/src/components/info-popover/info-popover.tsx
@@ -18,8 +18,7 @@ export class InfoPopover {
 
   @Prop() placement: Placement = "bottom-start";
 
-  private handleTriggerClick = (event: MouseEvent) => {
-    event.preventDefault();
+  private handleTriggerClick = () => {
     this.isOpen = !this.isOpen;
   };
 
@@ -38,8 +37,7 @@ export class InfoPopover {
           <div
             class={`popover ${this.placement}`}
             role="tooltip"
-            aria-describedby="popover-trigger"
-            aria-hidden={!this.isOpen ? "true" : "false"}
+            aria-labelledby="popover-trigger"
           >
             <a
               href="https://geneontology.github.io/web-components/"

--- a/packages/web-components/src/components/info-popover/info-popover.tsx
+++ b/packages/web-components/src/components/info-popover/info-popover.tsx
@@ -26,14 +26,14 @@ export class InfoPopover {
   render() {
     return (
       <div class="container">
-        <buttton
+        <button
           class="trigger"
           id="popover-trigger"
           onClick={this.handleTriggerClick}
           aria-label="Information about component library"
         >
           ?
-        </buttton>
+        </button>
         {this.isOpen && (
           <div
             class={`popover ${this.placement}`}

--- a/packages/web-components/src/globals/models.ts
+++ b/packages/web-components/src/globals/models.ts
@@ -109,3 +109,17 @@ export type ColorByOption = "classes" | "annotations";
 export type SubjectPositionOption = "none" | "left" | "right";
 
 export type SelectionModeOption = "cell" | "column";
+
+export type Placement =
+  | "top"
+  | "top-start"
+  | "top-end"
+  | "right"
+  | "right-start"
+  | "right-end"
+  | "bottom"
+  | "bottom-start"
+  | "bottom-end"
+  | "left"
+  | "left-start"
+  | "left-end";

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -36,6 +36,9 @@
         <a href="/components/gocam-viewer-legend">go-gocam-viewer-legend</a>
       </li>
       <li>
+        <a href="/components/info-popover">go-info-popover</a>
+      </li>
+      <li>
         <a href="/components/spinner">go-spinner</a>
       </li>
     </ul>


### PR DESCRIPTION
Fixes #31 

These changes add a new `InfoPopover` component (tag name `<go-info-popover>`) which displays information about the component library, including the version number. The new component is integrated into the existing `AnnotationRibbonStrips` (used by `AnnotationRibbon`) and `GocamViewer` components.