### PR TITLE
Standardize TypeScript interface names

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -5,9 +5,9 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { ColorByOption, IRibbonCellEvent, IRibbonGroup, IRibbonGroupEvent, IRibbonModel, IRibbonSubject, Placement, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
+import { ColorByOption, Placement, RibbonCellEvent, RibbonData, RibbonGroup, RibbonGroupEvent, RibbonSubject, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
 import { Cam } from "./globals/@noctua.form";
-export { ColorByOption, IRibbonCellEvent, IRibbonGroup, IRibbonGroupEvent, IRibbonModel, IRibbonSubject, Placement, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
+export { ColorByOption, Placement, RibbonCellEvent, RibbonData, RibbonGroup, RibbonGroupEvent, RibbonSubject, SelectionModeOption, SubjectPositionOption, TableData } from "./globals/models";
 export { Cam } from "./globals/@noctua.form";
 export namespace Components {
     /**
@@ -181,7 +181,7 @@ export namespace Components {
           * @default "annotations"
          */
         "colorBy": ColorByOption;
-        "group": IRibbonGroup;
+        "group": RibbonGroup;
         /**
           * @default false
          */
@@ -202,7 +202,7 @@ export namespace Components {
           * @default false
          */
         "selected": boolean;
-        "subject": IRibbonSubject;
+        "subject": RibbonSubject;
     }
     /**
      * The Annotation Ribbon Strips component displays a grid of cells. Each row in the grid represents
@@ -276,7 +276,7 @@ export namespace Components {
           * Sets the data for the ribbon manually.  Once this method is called, the provided data will be used and changes to the subjects, subset, or apiEndpoint properties will not trigger a data fetch.
           * @param data
          */
-        "setData": (data: IRibbonModel | undefined) => Promise<void>;
+        "setData": (data: RibbonData | undefined) => Promise<void>;
         /**
           * If `true`, show the "all annotations" group.
           * @default true
@@ -320,7 +320,7 @@ export namespace Components {
           * @default true
          */
         "newTab": boolean;
-        "subject": IRibbonSubject;
+        "subject": RibbonSubject;
         /**
           * @default "/"
          */
@@ -523,12 +523,12 @@ declare global {
         new (): HTMLGoAnnotationRibbonCellElement;
     };
     interface HTMLGoAnnotationRibbonStripsElementEventMap {
-        "cellClick": IRibbonCellEvent;
-        "cellEnter": IRibbonCellEvent;
-        "cellLeave": IRibbonCellEvent;
-        "groupClick": IRibbonGroupEvent;
-        "groupEnter": IRibbonGroupEvent;
-        "groupLeave": IRibbonGroupEvent;
+        "cellClick": RibbonCellEvent;
+        "cellEnter": RibbonCellEvent;
+        "cellLeave": RibbonCellEvent;
+        "groupClick": RibbonGroupEvent;
+        "groupEnter": RibbonGroupEvent;
+        "groupLeave": RibbonGroupEvent;
     }
     /**
      * The Annotation Ribbon Strips component displays a grid of cells. Each row in the grid represents
@@ -866,7 +866,7 @@ declare namespace LocalJSX {
           * @default "annotations"
          */
         "colorBy"?: ColorByOption;
-        "group"?: IRibbonGroup;
+        "group"?: RibbonGroup;
         /**
           * @default false
          */
@@ -887,7 +887,7 @@ declare namespace LocalJSX {
           * @default false
          */
         "selected"?: boolean;
-        "subject"?: IRibbonSubject;
+        "subject"?: RibbonSubject;
     }
     /**
      * The Annotation Ribbon Strips component displays a grid of cells. Each row in the grid represents
@@ -951,27 +951,27 @@ declare namespace LocalJSX {
         /**
           * Emitted when a ribbon cell is clicked.
          */
-        "onCellClick"?: (event: GoAnnotationRibbonStripsCustomEvent<IRibbonCellEvent>) => void;
+        "onCellClick"?: (event: GoAnnotationRibbonStripsCustomEvent<RibbonCellEvent>) => void;
         /**
           * Emitted when the mouse enters a ribbon cell.
          */
-        "onCellEnter"?: (event: GoAnnotationRibbonStripsCustomEvent<IRibbonCellEvent>) => void;
+        "onCellEnter"?: (event: GoAnnotationRibbonStripsCustomEvent<RibbonCellEvent>) => void;
         /**
           * Emitted when the mouse leaves a ribbon cell.
          */
-        "onCellLeave"?: (event: GoAnnotationRibbonStripsCustomEvent<IRibbonCellEvent>) => void;
+        "onCellLeave"?: (event: GoAnnotationRibbonStripsCustomEvent<RibbonCellEvent>) => void;
         /**
           * Emitted when a group label is clicked.
          */
-        "onGroupClick"?: (event: GoAnnotationRibbonStripsCustomEvent<IRibbonGroupEvent>) => void;
+        "onGroupClick"?: (event: GoAnnotationRibbonStripsCustomEvent<RibbonGroupEvent>) => void;
         /**
           * Emitted when the mouse enters a group label.
          */
-        "onGroupEnter"?: (event: GoAnnotationRibbonStripsCustomEvent<IRibbonGroupEvent>) => void;
+        "onGroupEnter"?: (event: GoAnnotationRibbonStripsCustomEvent<RibbonGroupEvent>) => void;
         /**
           * Emitted when the mouse leaves a group label.
          */
-        "onGroupLeave"?: (event: GoAnnotationRibbonStripsCustomEvent<IRibbonGroupEvent>) => void;
+        "onGroupLeave"?: (event: GoAnnotationRibbonStripsCustomEvent<RibbonGroupEvent>) => void;
         /**
           * If no value is provided, the ribbon will load without any group selected. If a value is provided, the ribbon will show the requested group as selected The value should be the id of the group to be selected
          */
@@ -1028,7 +1028,7 @@ declare namespace LocalJSX {
           * This event is triggered whenever a subject label is clicked Can call preventDefault() to avoid the default behavior (opening the linked subject page)
          */
         "onSubjectClick"?: (event: GoAnnotationRibbonSubjectCustomEvent<any>) => void;
-        "subject": IRibbonSubject;
+        "subject": RibbonSubject;
         /**
           * @default "/"
          */

--- a/packages/web-components/src/components/annotation-ribbon-cell/annotation-ribbon-cell.tsx
+++ b/packages/web-components/src/components/annotation-ribbon-cell/annotation-ribbon-cell.tsx
@@ -9,8 +9,8 @@ import {
 
 import {
   ColorByOption,
-  IRibbonGroup,
-  IRibbonSubject,
+  RibbonGroup,
+  RibbonSubject,
 } from "../../globals/models";
 
 /**
@@ -24,8 +24,8 @@ import {
   shadow: true,
 })
 export class AnnotationRibbonCell {
-  @Prop() subject: IRibbonSubject;
-  @Prop() group: IRibbonGroup;
+  @Prop() subject: RibbonSubject;
+  @Prop() group: RibbonGroup;
 
   @Prop() classLabels = "term,terms";
   @Prop() annotationLabels = "annotation,annotations";

--- a/packages/web-components/src/components/annotation-ribbon-strips/annotation-ribbon-strips.tsx
+++ b/packages/web-components/src/components/annotation-ribbon-strips/annotation-ribbon-strips.tsx
@@ -16,19 +16,19 @@ import { groupKey, cellKey, truncate, getNbAnnotations } from "./utils";
 
 import {
   ColorByOption,
-  IRibbonCategory,
-  IRibbonCellEvent,
-  IRibbonGroup,
-  IRibbonGroupEvent,
-  IRibbonModel,
-  IRibbonSubject,
+  RibbonCategory,
+  RibbonCellEvent,
+  RibbonGroup,
+  RibbonGroupEvent,
+  RibbonData,
+  RibbonSubject,
   SelectionModeOption,
   SubjectPositionOption,
 } from "../../globals/models";
 import { sameArray } from "../../globals/utils";
 import { getRibbonSummary } from "../../globals/api";
 
-const GROUP_ALL: IRibbonGroup = {
+const GROUP_ALL: RibbonGroup = {
   id: "all",
   label: "all annotations",
   description: "Show all annotations for all categories",
@@ -52,14 +52,14 @@ const GROUP_ALL: IRibbonGroup = {
 export class AnnotationRibbonStrips {
   private dataManuallySet: boolean = false;
 
-  @State() selectedGroup: IRibbonGroup | null = null;
-  @State() selectedSubjects: IRibbonSubject[] = [];
-  @State() hoveredGroup: IRibbonGroup | null = null;
-  @State() hoveredSubjects: IRibbonSubject[] = [];
+  @State() selectedGroup: RibbonGroup | null = null;
+  @State() selectedSubjects: RibbonSubject[] = [];
+  @State() hoveredGroup: RibbonGroup | null = null;
+  @State() hoveredSubjects: RibbonSubject[] = [];
 
   @State() loading: boolean = false;
   @State() loadingError: boolean = false;
-  @State() data?: IRibbonModel;
+  @State() data?: RibbonData;
 
   /**
    * Comma-separated list of gene IDs (e.g. RGD:620474,RGD:3889)
@@ -203,37 +203,37 @@ export class AnnotationRibbonStrips {
    * Emitted when a ribbon cell is clicked.
    */
   @Event({ eventName: "cellClick", cancelable: true, bubbles: true })
-  cellClick: EventEmitter<IRibbonCellEvent>;
+  cellClick: EventEmitter<RibbonCellEvent>;
 
   /**
    * Emitted when the mouse enters a ribbon cell.
    */
   @Event({ eventName: "cellEnter", cancelable: true, bubbles: true })
-  cellEnter: EventEmitter<IRibbonCellEvent>;
+  cellEnter: EventEmitter<RibbonCellEvent>;
 
   /**
    * Emitted when the mouse leaves a ribbon cell.
    */
   @Event({ eventName: "cellLeave", cancelable: true, bubbles: true })
-  cellLeave: EventEmitter<IRibbonCellEvent>;
+  cellLeave: EventEmitter<RibbonCellEvent>;
 
   /**
    * Emitted when a group label is clicked.
    */
   @Event({ eventName: "groupClick", cancelable: true, bubbles: true })
-  groupClick: EventEmitter<IRibbonGroupEvent>;
+  groupClick: EventEmitter<RibbonGroupEvent>;
 
   /**
    * Emitted when the mouse enters a group label.
    */
   @Event({ eventName: "groupEnter", cancelable: true, bubbles: true })
-  groupEnter: EventEmitter<IRibbonGroupEvent>;
+  groupEnter: EventEmitter<RibbonGroupEvent>;
 
   /**
    * Emitted when the mouse leaves a group label.
    */
   @Event({ eventName: "groupLeave", cancelable: true, bubbles: true })
-  groupLeave: EventEmitter<IRibbonGroupEvent>;
+  groupLeave: EventEmitter<RibbonGroupEvent>;
 
   /**
    * Lifecycle method called when the component has loaded.
@@ -253,7 +253,7 @@ export class AnnotationRibbonStrips {
    * @param data
    */
   @Method()
-  async setData(data: IRibbonModel | undefined) {
+  async setData(data: RibbonData | undefined) {
     this.dataManuallySet = true;
     if (!data) {
       this.selectedGroup = null;
@@ -283,7 +283,7 @@ export class AnnotationRibbonStrips {
     }
   }
 
-  private groupsEqual(a: IRibbonGroup | null, b: IRibbonGroup | null): boolean {
+  private groupsEqual(a: RibbonGroup | null, b: RibbonGroup | null): boolean {
     // If objects are the same reference, return true
     if (a === b) {
       return true;
@@ -296,11 +296,11 @@ export class AnnotationRibbonStrips {
     return a.id === b.id && a.type === b.type;
   }
 
-  private subjectsEqual(a: IRibbonSubject[], b: IRibbonSubject[]): boolean {
+  private subjectsEqual(a: RibbonSubject[], b: RibbonSubject[]): boolean {
     return sameArray(a, b, (s1, s2) => s1.id === s2.id);
   }
 
-  private onCellEnter(subject: IRibbonSubject, group: IRibbonGroup) {
+  private onCellEnter(subject: RibbonSubject, group: RibbonGroup) {
     if (this.selectionMode === "column") {
       this.hoveredSubjects = this.data.subjects;
     } else {
@@ -323,7 +323,7 @@ export class AnnotationRibbonStrips {
     this.hoveredGroup = null;
   }
 
-  private onCellClick(subject: IRibbonSubject, group: IRibbonGroup) {
+  private onCellClick(subject: RibbonSubject, group: RibbonGroup) {
     const numberOfAnnotations = getNbAnnotations(group, subject);
     if (numberOfAnnotations === 0) {
       return;
@@ -346,7 +346,7 @@ export class AnnotationRibbonStrips {
     });
   }
 
-  private onGroupClick(category: IRibbonCategory, group: IRibbonGroup) {
+  private onGroupClick(category: RibbonCategory, group: RibbonGroup) {
     if (!this.groupClickable) {
       return;
     }
@@ -370,7 +370,7 @@ export class AnnotationRibbonStrips {
     });
   }
 
-  private onGroupEnter(category: IRibbonCategory, group: IRibbonGroup) {
+  private onGroupEnter(category: RibbonCategory, group: RibbonGroup) {
     this.hoveredGroup = group;
     this.hoveredSubjects = this.data.subjects;
     this.groupEnter.emit({
@@ -379,7 +379,7 @@ export class AnnotationRibbonStrips {
     });
   }
 
-  private onGroupLeave(category: IRibbonCategory, group: IRibbonGroup) {
+  private onGroupLeave(category: RibbonCategory, group: RibbonGroup) {
     this.hoveredGroup = null;
     this.hoveredSubjects = [];
     this.groupLeave.emit({
@@ -388,25 +388,22 @@ export class AnnotationRibbonStrips {
     });
   }
 
-  private isGroupHovered(group: IRibbonGroup): boolean {
+  private isGroupHovered(group: RibbonGroup): boolean {
     return this.groupsEqual(this.hoveredGroup, group);
   }
 
-  private isCellHovered(subject: IRibbonSubject, group: IRibbonGroup): boolean {
+  private isCellHovered(subject: RibbonSubject, group: RibbonGroup): boolean {
     return (
       this.isGroupHovered(group) &&
       this.hoveredSubjects.findIndex((s) => s.id === subject.id) >= 0
     );
   }
 
-  private isGroupSelected(group: IRibbonGroup): boolean {
+  private isGroupSelected(group: RibbonGroup): boolean {
     return this.groupsEqual(this.selectedGroup, group);
   }
 
-  private isCellSelected(
-    subject: IRibbonSubject,
-    group: IRibbonGroup,
-  ): boolean {
+  private isCellSelected(subject: RibbonSubject, group: RibbonGroup): boolean {
     return (
       this.isGroupSelected(group) &&
       this.selectedSubjects.findIndex((s) => s.id === subject.id) >= 0
@@ -417,7 +414,7 @@ export class AnnotationRibbonStrips {
     return truncate(category, this.groupMaxLabelSize, "...");
   }
 
-  private formatGroupTitle(group: IRibbonGroup): string {
+  private formatGroupTitle(group: RibbonGroup): string {
     return `${group.id}: ${group.label}\n\n${group.description}`;
   }
 
@@ -479,45 +476,44 @@ export class AnnotationRibbonStrips {
             </th>
           )}
 
-          {this.data.categories.map(
-            (category: IRibbonCategory, categoryIndex) =>
-              category.groups.map((group: IRibbonGroup, groupIndex) =>
-                group.type === "Other" && !this.showOtherGroup ? null : (
-                  <Fragment>
-                    {groupIndex === 0 &&
-                      (categoryIndex > 0 || this.showAllAnnotationsGroup) && (
-                        <th class="separator" />
-                      )}
-                    <th
+          {this.data.categories.map((category: RibbonCategory, categoryIndex) =>
+            category.groups.map((group: RibbonGroup, groupIndex) =>
+              group.type === "Other" && !this.showOtherGroup ? null : (
+                <Fragment>
+                  {groupIndex === 0 &&
+                    (categoryIndex > 0 || this.showAllAnnotationsGroup) && (
+                      <th class="separator" />
+                    )}
+                  <th
+                    class={clsx({
+                      group: true,
+                      "category-all": group.type === "All",
+                      "category-other": group.type === "Other",
+                      hovered: this.isGroupHovered(group),
+                      selected: this.isGroupSelected(group),
+                    })}
+                    key={groupKey(group)}
+                    title={this.formatGroupTitle(group)}
+                  >
+                    <div
                       class={clsx({
-                        group: true,
-                        "category-all": group.type === "All",
-                        "category-other": group.type === "Other",
-                        hovered: this.isGroupHovered(group),
-                        selected: this.isGroupSelected(group),
+                        label: true,
+                        clickable: this.groupClickable,
                       })}
-                      key={groupKey(group)}
-                      title={this.formatGroupTitle(group)}
+                      onMouseEnter={() => this.onGroupEnter(category, group)}
+                      onMouseLeave={() => this.onGroupLeave(category, group)}
+                      onClick={
+                        this.groupClickable
+                          ? () => this.onGroupClick(category, group)
+                          : undefined
+                      }
                     >
-                      <div
-                        class={clsx({
-                          label: true,
-                          clickable: this.groupClickable,
-                        })}
-                        onMouseEnter={() => this.onGroupEnter(category, group)}
-                        onMouseLeave={() => this.onGroupLeave(category, group)}
-                        onClick={
-                          this.groupClickable
-                            ? () => this.onGroupClick(category, group)
-                            : undefined
-                        }
-                      >
-                        {this.formatGroupLabel(group.label)}
-                      </div>
-                    </th>
-                  </Fragment>
-                ),
+                      {this.formatGroupLabel(group.label)}
+                    </div>
+                  </th>
+                </Fragment>
               ),
+            ),
           )}
           {this.subjectPosition === "right" && <th />}
         </tr>
@@ -528,7 +524,7 @@ export class AnnotationRibbonStrips {
   renderSubjects() {
     return (
       <tbody>
-        {this.data.subjects.map((subject: IRibbonSubject) => {
+        {this.data.subjects.map((subject: RibbonSubject) => {
           return (
             <tr key={subject.id}>
               {this.subjectPosition === "left" && (
@@ -563,8 +559,8 @@ export class AnnotationRibbonStrips {
               )}
 
               {this.data.categories.map(
-                (category: IRibbonCategory, categoryIndex) =>
-                  category.groups.map((group: IRibbonGroup, groupIndex) => {
+                (category: RibbonCategory, categoryIndex) =>
+                  category.groups.map((group: RibbonGroup, groupIndex) => {
                     const cellid =
                       group.id + (group.type === "Other" ? "-other" : "");
                     const cell =

--- a/packages/web-components/src/components/annotation-ribbon-strips/utils.ts
+++ b/packages/web-components/src/components/annotation-ribbon-strips/utils.ts
@@ -1,4 +1,4 @@
-import { IRibbonGroup, IRibbonSubject } from "../../globals/models";
+import { RibbonGroup, RibbonSubject } from "../../globals/models";
 
 export function truncate(text, size, ending) {
   if (size == null) {
@@ -18,15 +18,15 @@ export function transformID(txt) {
   return txt.replace(":", "_");
 }
 
-export function groupKey(group: IRibbonGroup) {
+export function groupKey(group: RibbonGroup) {
   return `category-${transformID(group.id)}-${group.type}`;
 }
 
-export function cellKey(subject: IRibbonSubject, group: IRibbonGroup) {
+export function cellKey(subject: RibbonSubject, group: RibbonGroup) {
   return `subject-${transformID(subject.id)}-${groupKey(group)}`;
 }
 
-export function getNbClasses(group: IRibbonGroup, subject: IRibbonSubject) {
+export function getNbClasses(group: RibbonGroup, subject: RibbonSubject) {
   if (group.type == "GlobalAll") {
     return subject.nb_classes;
   }
@@ -35,7 +35,7 @@ export function getNbClasses(group: IRibbonGroup, subject: IRibbonSubject) {
   return cell ? cell["ALL"]["nb_classes"] : 0;
 }
 
-export function getNbAnnotations(group: IRibbonGroup, subject: IRibbonSubject) {
+export function getNbAnnotations(group: RibbonGroup, subject: RibbonSubject) {
   if (group.type == "GlobalAll") {
     return subject.nb_annotations;
   }

--- a/packages/web-components/src/components/annotation-ribbon-subject/annotation-ribbon-subject.tsx
+++ b/packages/web-components/src/components/annotation-ribbon-subject/annotation-ribbon-subject.tsx
@@ -1,7 +1,7 @@
 import { Component, Event, EventEmitter, h, Prop, Watch } from "@stencil/core";
 
 import { formatTaxonLabel } from "./utils";
-import { IRibbonSubject } from "../../globals/models";
+import { RibbonSubject } from "../../globals/models";
 
 /**
  * An individual subject in the annotation ribbon.
@@ -17,7 +17,7 @@ export class AnnotationRibbonSubject {
   private subjectId: string;
   private subjectBaseURLFull: string = "/";
 
-  @Prop() subject!: IRibbonSubject;
+  @Prop() subject!: RibbonSubject;
 
   @Prop()
   get subjectBaseURL(): string {

--- a/packages/web-components/src/components/annotation-ribbon-table/annotation-ribbon-table.tsx
+++ b/packages/web-components/src/components/annotation-ribbon-table/annotation-ribbon-table.tsx
@@ -1,9 +1,9 @@
 import { Component, h, Method, Prop, State, Watch } from "@stencil/core";
 
 import {
-  IHeaderCell,
-  ISuperCell,
-  ITable,
+  DisplayHeaderCell,
+  DisplaySuperCell,
+  DisplayTable,
   TableData,
 } from "../../globals/models";
 import { addEmptyCells, bioLinkToTable } from "./utils";
@@ -24,10 +24,10 @@ import { Draft, Immutable, produce } from "immer";
 export class AnnotationRibbonTable {
   @State() loading: boolean = false;
   @State() loadingError: boolean = false;
-  @State() displayTable?: Immutable<ITable>;
+  @State() displayTable?: Immutable<DisplayTable>;
 
   private tableData?: Immutable<TableData>;
-  private headerMap?: Map<string, Immutable<IHeaderCell>>;
+  private headerMap?: Map<string, Immutable<DisplayHeaderCell>>;
   private dataManuallySet: boolean = false;
 
   /**
@@ -200,7 +200,7 @@ export class AnnotationRibbonTable {
     }
     this.displayTable = Object.freeze(displayTable);
 
-    const map = new Map<string, Immutable<IHeaderCell>>();
+    const map = new Map<string, Immutable<DisplayHeaderCell>>();
     for (const header of this.displayTable.header) {
       map.set(header.id, header);
     }
@@ -212,7 +212,7 @@ export class AnnotationRibbonTable {
    * @param table the table to be grouped
    * @param keyColumns ids of the columns to create unique rows - will only work with cells containing single value, not array
    */
-  private groupByColumns(table: ITable, keyColumns: string[]) {
+  private groupByColumns(table: DisplayTable, keyColumns: string[]) {
     const firstRow = table.rows[0].cells;
     const otherCells = firstRow.filter(
       (elt) => !keyColumns.includes(elt.headerId),
@@ -251,7 +251,7 @@ export class AnnotationRibbonTable {
       const rrows = uRows.get(key);
       const row = { cells: [] };
       for (const header of table.header) {
-        let eqcell: ISuperCell = undefined;
+        let eqcell: DisplaySuperCell = undefined;
         if (keyColumns.includes(header.id)) {
           eqcell = rrows[0].cells.filter((elt) => elt.headerId == header.id)[0];
         } else if (otherColumns.includes(header.id)) {
@@ -285,7 +285,7 @@ export class AnnotationRibbonTable {
     table.rows = newRows;
   }
 
-  private filterByColumns(table: ITable, filters: string) {
+  private filterByColumns(table: DisplayTable, filters: string) {
     const split = filters.split(":");
     const key = split[0];
     const values = split[1].split(",");
@@ -339,7 +339,7 @@ export class AnnotationRibbonTable {
     );
   }
 
-  renderHeader(table: Immutable<ITable>) {
+  renderHeader(table: Immutable<DisplayTable>) {
     return (
       <tr class="header">
         {table.header.map((cell) => {
@@ -360,7 +360,7 @@ export class AnnotationRibbonTable {
     );
   }
 
-  renderRows(table: Immutable<ITable>) {
+  renderRows(table: Immutable<DisplayTable>) {
     return table.rows.map((row) => (
       <tr class="row">
         {row.cells.map((superCell) => {

--- a/packages/web-components/src/components/annotation-ribbon-table/utils.tsx
+++ b/packages/web-components/src/components/annotation-ribbon-table/utils.tsx
@@ -1,4 +1,4 @@
-import { ITable, TableData } from "../../globals/models";
+import { DisplayTable, TableData } from "../../globals/models";
 import { Immutable } from "immer";
 
 /**
@@ -8,7 +8,7 @@ import { Immutable } from "immer";
  * Note: Should only be launched once on a table
  * @param table
  */
-export function addEmptyCells(table: ITable) {
+export function addEmptyCells(table: DisplayTable) {
   for (const row of table.rows) {
     let nbMax = 0;
     for (const header of table.header) {
@@ -38,8 +38,8 @@ export function aspectShortLabel(txt) {
 export function bioLinkToTable(
   data: Immutable<TableData>,
   getURL: (db: string, type: string | undefined, id: string) => string,
-): ITable {
-  const table: ITable = {
+): DisplayTable {
+  const table: DisplayTable = {
     newTab: true,
     header: [
       {

--- a/packages/web-components/src/components/annotation-ribbon/annotation-ribbon.tsx
+++ b/packages/web-components/src/components/annotation-ribbon/annotation-ribbon.tsx
@@ -2,11 +2,11 @@ import { Component, h, Host, Listen, Prop, State, Watch } from "@stencil/core";
 
 import {
   ColorByOption,
-  IRibbonCellEvent,
-  IRibbonGroup,
-  IRibbonGroupEvent,
-  IRibbonModel,
-  IRibbonSubject,
+  RibbonCellEvent,
+  RibbonGroup,
+  RibbonGroupEvent,
+  RibbonData,
+  RibbonSubject,
   SelectionModeOption,
   SubjectPositionOption,
   TableData,
@@ -38,7 +38,7 @@ export class AnnotationRibbon {
   private stripsElement: HTMLGoAnnotationRibbonStripsElement;
   private tableElement: HTMLGoAnnotationRibbonTableElement;
 
-  @State() ribbonData?: IRibbonModel;
+  @State() ribbonData?: RibbonData;
   @State() ribbonDataLoading = false;
   @State() ribbonDataLoadingError = false;
 
@@ -239,10 +239,7 @@ export class AnnotationRibbon {
     }
   }
 
-  private async fetchTableData(
-    group: IRibbonGroup,
-    subjects: IRibbonSubject[],
-  ) {
+  private async fetchTableData(group: RibbonGroup, subjects: RibbonSubject[]) {
     if (!this.ribbonData) {
       return;
     }
@@ -295,13 +292,13 @@ export class AnnotationRibbon {
     }
   }
 
-  private applyTableFilters(data: TableData, group: IRibbonGroup) {
+  private applyTableFilters(data: TableData, group: RibbonGroup) {
     if (this.filterCrossAspect) {
       this.applyFilterCrossAspect(data, group);
     }
   }
 
-  private applyFilterCrossAspect(data: TableData, group: IRibbonGroup) {
+  private applyFilterCrossAspect(data: TableData, group: RibbonGroup) {
     if (!this.ribbonData) {
       return;
     }
@@ -318,7 +315,7 @@ export class AnnotationRibbon {
   }
 
   @Listen("cellClick")
-  onCellClick(e: CustomEvent<IRibbonCellEvent>) {
+  onCellClick(e: CustomEvent<RibbonCellEvent>) {
     if (!this.ribbonData) {
       return;
     }
@@ -332,7 +329,7 @@ export class AnnotationRibbon {
   }
 
   @Listen("groupClick")
-  onGroupClick(e: CustomEvent<IRibbonGroupEvent>) {
+  onGroupClick(e: CustomEvent<RibbonGroupEvent>) {
     if (!this.ribbonData) {
       return;
     }

--- a/packages/web-components/src/components/annotation-ribbon/utils.ts
+++ b/packages/web-components/src/components/annotation-ribbon/utils.ts
@@ -1,16 +1,13 @@
 import {
-  IRibbonCategory,
-  IRibbonGroup,
+  RibbonCategory,
+  RibbonGroup,
   TableDataAssociation,
 } from "../../globals/models";
 
 /**
  * Return the category object for a given group
  */
-export function getCategory(
-  group: IRibbonGroup,
-  categories: IRibbonCategory[],
-) {
+export function getCategory(group: RibbonGroup, categories: RibbonCategory[]) {
   const cat = categories.filter((cat) => {
     return cat.groups.some((gp) => gp.id == group.id);
   });
@@ -21,8 +18,8 @@ export function getCategory(
  * Return the category [id, label] for a given group
  */
 export function getCategoryIdLabel(
-  group: IRibbonGroup,
-  categories: IRibbonCategory[],
+  group: RibbonGroup,
+  categories: RibbonCategory[],
 ) {
   const cat = categories.filter((cat) => {
     return cat.groups.some((gp) => gp.id == group.id);

--- a/packages/web-components/src/globals/api.ts
+++ b/packages/web-components/src/globals/api.ts
@@ -1,4 +1,4 @@
-import { IRibbonModel, TableData } from "./models";
+import { RibbonData, TableData } from "./models";
 
 async function getJson<T>(url: string, options: RequestInit = {}): Promise<T> {
   const response = await fetch(url, options);
@@ -24,7 +24,7 @@ export async function getRibbonSummary(
   });
 
   const url = endpointUrl + "?" + params.toString();
-  return await getJson<IRibbonModel>(url);
+  return await getJson<RibbonData>(url);
 }
 
 export async function getTableData(

--- a/packages/web-components/src/globals/models.ts
+++ b/packages/web-components/src/globals/models.ts
@@ -1,18 +1,18 @@
-export interface IRibbonGroup {
+export interface RibbonGroup {
   id: string;
   label: string;
   description: string;
   type: "GlobalAll" | "All" | "Term" | "Other";
 }
 
-export interface IRibbonCategory {
+export interface RibbonCategory {
   id: string;
   label: string;
   description: string;
-  groups: IRibbonGroup[];
+  groups: RibbonGroup[];
 }
 
-export interface IRibbonSubject {
+export interface RibbonSubject {
   id: string;
   label: string;
   taxon_id: string;
@@ -22,31 +22,31 @@ export interface IRibbonSubject {
   groups: Record<string, never>;
 }
 
-export interface IRibbonModel {
-  categories: IRibbonCategory[];
-  subjects: IRibbonSubject[];
+export interface RibbonData {
+  categories: RibbonCategory[];
+  subjects: RibbonSubject[];
 }
 
-export interface IRibbonCellEvent {
-  subjects: IRibbonSubject[];
-  group: IRibbonGroup | null;
+export interface RibbonCellEvent {
+  subjects: RibbonSubject[];
+  group: RibbonGroup | null;
 }
 
-export interface IRibbonGroupEvent {
-  category: IRibbonCategory;
-  group: IRibbonGroup;
+export interface RibbonGroupEvent {
+  category: RibbonCategory;
+  group: RibbonGroup;
 }
 
-export interface ISuperCell {
+export interface DisplaySuperCell {
   id?: string;
   headerId: string;
   clickable?: boolean;
   selectable?: boolean;
   foldable?: boolean;
-  values: ICell[];
+  values: DisplayCell[];
 }
 
-export interface ICell {
+export interface DisplayCell {
   id?: string;
   label: string;
   description?: string;
@@ -56,20 +56,20 @@ export interface ICell {
   selectable?: boolean;
 }
 
-export interface IHeaderCell extends ICell {
+export interface DisplayHeaderCell extends DisplayCell {
   baseURL?: string; // if defined, convert cell URL to use this baseURL
   hide?: boolean; // if true, won't show the column that would be considered only for treatment (eg grouping)
 }
 
-export interface IRow {
+export interface DisplayRow {
   foldable?: boolean;
   // id?: string;
-  cells: ISuperCell[];
+  cells: DisplaySuperCell[];
 }
 
-export interface ITable {
-  header: IHeaderCell[];
-  rows: IRow[];
+export interface DisplayTable {
+  header: DisplayHeaderCell[];
+  rows: DisplayRow[];
   newTab?: boolean;
 }
 

--- a/website/docs/components/annotation-ribbon-strips/readme.md
+++ b/website/docs/components/annotation-ribbon-strips/readme.md
@@ -40,19 +40,19 @@ Events are fired when cells or cell headers (groups) are clicked or hovered over
 
 ## Events
 
-| Event        | Description                                  | Type                             |
-| ------------ | -------------------------------------------- | -------------------------------- |
-| `cellClick`  | Emitted when a ribbon cell is clicked.       | `CustomEvent<IRibbonCellEvent>`  |
-| `cellEnter`  | Emitted when the mouse enters a ribbon cell. | `CustomEvent<IRibbonCellEvent>`  |
-| `cellLeave`  | Emitted when the mouse leaves a ribbon cell. | `CustomEvent<IRibbonCellEvent>`  |
-| `groupClick` | Emitted when a group label is clicked.       | `CustomEvent<IRibbonGroupEvent>` |
-| `groupEnter` | Emitted when the mouse enters a group label. | `CustomEvent<IRibbonGroupEvent>` |
-| `groupLeave` | Emitted when the mouse leaves a group label. | `CustomEvent<IRibbonGroupEvent>` |
+| Event        | Description                                  | Type                            |
+| ------------ | -------------------------------------------- | ------------------------------- |
+| `cellClick`  | Emitted when a ribbon cell is clicked.       | `CustomEvent<RibbonCellEvent>`  |
+| `cellEnter`  | Emitted when the mouse enters a ribbon cell. | `CustomEvent<RibbonCellEvent>`  |
+| `cellLeave`  | Emitted when the mouse leaves a ribbon cell. | `CustomEvent<RibbonCellEvent>`  |
+| `groupClick` | Emitted when a group label is clicked.       | `CustomEvent<RibbonGroupEvent>` |
+| `groupEnter` | Emitted when the mouse enters a group label. | `CustomEvent<RibbonGroupEvent>` |
+| `groupLeave` | Emitted when the mouse leaves a group label. | `CustomEvent<RibbonGroupEvent>` |
 
 
 ## Methods
 
-### `setData(data: IRibbonModel | undefined) => Promise<void>`
+### `setData(data: RibbonData | undefined) => Promise<void>`
 
 Sets the data for the ribbon manually.
 
@@ -61,9 +61,9 @@ subset, or apiEndpoint properties will not trigger a data fetch.
 
 #### Parameters
 
-| Name   | Type           | Description |
-| ------ | -------------- | ----------- |
-| `data` | `IRibbonModel` |             |
+| Name   | Type         | Description |
+| ------ | ------------ | ----------- |
+| `data` | `RibbonData` |             |
 
 #### Returns
 


### PR DESCRIPTION
* Removes the `I` prefix on interface names. Prefixing is generally discouraged by most TypeScript style guides.
* Renames a few ribbon table-related interfaces to distinguish between table data (which comes from the API directly) and display table data (which is derived from the raw table data).