### PR TITLE
Use trusted publishing for NPM package

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "Feature request / bug report"
 about: This describes a new feature or reports a current bug
-title: 
-labels: 
-assignees: 
+title:
+labels:
+assignees:
 ---

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish --provenance --access public --workspace ${{ inputs.package }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Remove the NODE_AUTH_TOKEN variable from the publish workflow now that trusted publishing is set up on the NPM side.